### PR TITLE
Update httpstream.go

### DIFF
--- a/dockerfiles/logspout/httpstream/httpstream.go
+++ b/dockerfiles/logspout/httpstream/httpstream.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"strconv"
 
-	"code.google.com/p/go.net/websocket"
+	"golang.org/x/net/websocket"
 	"github.com/gorilla/mux"
 
 	"github.com/gliderlabs/logspout/router"


### PR DESCRIPTION
thanks for blog post and repo. 
I tried to build it but it seems that there was a shutdown of code.google.com  (http://google-opensource.blogspot.de/2015/03/farewell-to-google-code.html) and the link to the websocket seems to be broken (go get).
I found somewhere (stackoverflow?) the link to the websocket.
perhaps this helps someone else...
