### PR TITLE
Update a missing dash - build error

### DIFF
--- a/docker-compose-common.yml
+++ b/docker-compose-common.yml
@@ -16,7 +16,7 @@ kibana:
     - "80:80"
 logspout:
   environment:
-    DEBUG: true
+    - DEBUG: true
   volumes:
     - /var/run/docker.sock:/var/run/docker.sock
   command: syslog://localhost:5000


### PR DESCRIPTION
found a typo on DEBUG, there should be a dash (-) in front, then docker compose will not complain because of error
